### PR TITLE
Fix SF in the cleanup() method

### DIFF
--- a/include/fswatch.hpp
+++ b/include/fswatch.hpp
@@ -79,10 +79,9 @@ public:
     return rwatch[elem];
   }
   void cleanup(int fd) {
-    for (std::map<int, wd_elem>::iterator wi = watch.begin(); wi != watch.end();
-         wi++) {
+    for (auto wi = watch.begin(); wi != watch.end();) {
       inotify_rm_watch(fd, wi->first);
-      watch.erase(wi);
+      wi = watch.erase(wi);
     }
     rwatch.clear();
   }


### PR DESCRIPTION
This PR refers to an issue #6.
The iterator will be lost after the entry is erased, resulting to SF. This change fixes the problem.